### PR TITLE
fix(#4): jar-path when drive-letter is nil or empty.

### DIFF
--- a/lsp-intellij.el
+++ b/lsp-intellij.el
@@ -184,7 +184,7 @@ Return the file path if found, nil otherwise."
          (drive-letter (url-host url))
          (raw (url-filename url))
          (paths (split-string raw "!/"))
-         (jar-path (concat drive-letter ":" (car paths)))
+         (jar-path (if (and (not drive-letter) (string= "" drive-letter)) (concat drive-letter ":" (car paths)) (car paths)))
          (internal-path (cadr paths))
          (temp-path (lsp-intellij--make-jar-temp-path jar-path internal-path))
          (is-source-file (string-match-p lsp-intellij--file-extracted-from-jar-regex internal-path))


### PR DESCRIPTION
I don't have a deep understanding of the code, but this fixes the problem with me.